### PR TITLE
Remove compatiblity with 251.x and 252.x idea build

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <description>Standalone HOCON plugin for IntelliJ IDEA</description>
     <version>2025.1.99-SNAPSHOT</version>
     <vendor>Roman Janusz, AVSystem, JetBrains</vendor>
-    <idea-version since-build="251.0" until-build="260.0"/>
+    <idea-version since-build="253.0" until-build="260.0"/>
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>
     <depends>com.intellij.modules.json</depends>


### PR DESCRIPTION
Updated the `plugin.xml` file to set the `since-build` property to 253.0, ensuring compatibility with the appropriate IntelliJ platform builds. This update aligns the plugin with recent platform requirements.