### PR TITLE
Enforce scalafmt in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Check Scala formatting
+        run: sbt '++ ${{ matrix.scala }}' scalafmtCheckAll scalafmtSbtCheck
+
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,12 @@ ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / intellijPluginName := "intellij-hocon"
 ThisBuild / intellijBuild := "261.20869.57"
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("21"))
+// Run scalafmt inside the build job rather than as a separate job: loading this build pulls
+// the full IntelliJ SDK, which CI doesn't cache, so a standalone job would re-download it.
+ThisBuild / githubWorkflowBuildPreamble += WorkflowStep.Sbt(
+  List("scalafmtCheckAll", "scalafmtSbtCheck"),
+  name = Some("Check Scala formatting"),
+)
 ThisBuild / autoRemoveOldCachedIntelliJSDK := true
 ThisBuild / autoRemoveOldCachedDownloads := true
 


### PR DESCRIPTION
## Summary

- Adds a `Check Scala formatting` step to the existing `build` job that runs `scalafmtCheckAll` + `scalafmtSbtCheck` on every PR.
- Wired as a build-job step (not a separate job) because loading this build pulls the full IntelliJ SDK (~800MB), which CI doesn't cache — a standalone job would re-download it on every run. Sharing the build job's download avoids that.

## Why

Part of standardizing scalafmt enforcement across our Scala repos (following scala-commons). intellij-hocon already had `.scalafmt.conf` (3.11.1) and the `sbt-scalafmt` plugin (2.6.1) plus a history of reformats, but nothing verified formatting in CI. With AI-assisted edits more common, a cheap CI gate is worth it.

## Test plan

- [x] `sbt scalafmtCheckAll scalafmtSbtCheck` passes locally on master (no drift)
- [x] `sbt githubWorkflowCheck` passes (generated workflow matches build config)
- [ ] CI green on this PR; the new formatting step runs before the build/test step