### PR TITLE
Cache IntelliJ SDK in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Cache IntelliJ SDK
+        uses: actions/cache@v4
+        with:
+          path: ~/.intellij-hoconPluginIC
+          key: ${{ runner.os }}-intellij-sdk-${{ hashFiles('build.sbt') }}
+          restore-keys: ${{ runner.os }}-intellij-sdk-
+
       - name: Check Scala formatting
         run: sbt '++ ${{ matrix.scala }}' scalafmtCheckAll scalafmtSbtCheck
 

--- a/build.sbt
+++ b/build.sbt
@@ -46,8 +46,7 @@ lazy val hocon = project
       "-Xsource:3",
     ),
     ideBasePackages := Seq("org.jetbrains.plugins.hocon"),
-    intellijPlugins :=
-      Seq("com.intellij.java", "com.intellij.java-i18n", "com.intellij.modules.json").map(_.toPlugin),
+    intellijPlugins := Seq("com.intellij.java", "com.intellij.java-i18n", "com.intellij.modules.json").map(_.toPlugin),
     intellijExtraRuntimePluginsInTests := Seq("org.jetbrains.kotlin").map(_.toPlugin),
     resolvers += "JetBrains Intellij Repository".at("https://www.jetbrains.com/intellij-repository/snapshots"),
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,19 @@ ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / intellijPluginName := "intellij-hocon"
 ThisBuild / intellijBuild := "261.22158.260"
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("21"))
-// Run scalafmt inside the build job rather than as a separate job: loading this build pulls
-// the full IntelliJ SDK, which CI doesn't cache, so a standalone job would re-download it.
+// Cache the IntelliJ SDK (~800MB) that the sbt-idea-plugin downloads on build load; the default
+// sbt cache doesn't cover it. Keyed on build.sbt so an intellijBuild bump invalidates the entry.
+ThisBuild / githubWorkflowBuildPreamble += WorkflowStep.Use(
+  UseRef.Public("actions", "cache", "v4"),
+  name = Some("Cache IntelliJ SDK"),
+  params = Map(
+    "path" -> "~/.intellij-hoconPluginIC",
+    "key" -> "${{ runner.os }}-intellij-sdk-${{ hashFiles('build.sbt') }}",
+    "restore-keys" -> "${{ runner.os }}-intellij-sdk-",
+  ),
+)
+// Run scalafmt inside the build job (not a separate job) so it shares this job's single SDK
+// download/restore instead of needing its own.
 ThisBuild / githubWorkflowBuildPreamble += WorkflowStep.Sbt(
   List("scalafmtCheckAll", "scalafmtSbtCheck"),
   name = Some("Check Scala formatting"),


### PR DESCRIPTION
## Summary

The `sbt-idea-plugin` downloads the full IntelliJ SDK (~611MB IDE + ~221MB JBR) on build load, into `~/.intellij-hoconPluginIC`. The default `cache: sbt` (coursier/ivy/sbt-boot) doesn't cover that directory, so every CI run re-downloaded ~800MB.

This adds an `actions/cache@v4` step (first in the build job, before the scalafmt and build/test steps) so the SDK is restored once and reused.

- **Key:** `${{ runner.os }}-intellij-sdk-${{ hashFiles('build.sbt') }}` — `intellijBuild` lives in `build.sbt`, so a version bump correctly invalidates the entry.
- **restore-keys:** prefix fallback, so an unrelated `build.sbt` change still restores the same-version SDK fully (the plugin only tops up if needed).
- Plays well with the existing `autoRemoveOldCachedIntelliJSDK`/`autoRemoveOldCachedDownloads` settings, which keep the cached dir lean (one SDK version, no leftover archives).

Wired via `githubWorkflowBuildPreamble` in `build.sbt` (CI is generated by sbt-github-actions); `.github/workflows/ci.yml` is regenerated, not hand-edited.

## Why it's worth it

Version bumps on master are infrequent (~every 1-2 months), so most runs — code PRs, scala-steward dep bumps — hit a warm cache and skip the download. Version-bump PRs miss, which is unavoidable.

## Test plan

- [x] `sbt githubWorkflowGenerate` + `githubWorkflowCheck` pass (workflow matches build config)
- [ ] CI: first run populates the cache (miss); confirm subsequent runs report a cache hit and skip the SDK download