### PR TITLE
Add Structure View for HOCON files

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -46,6 +46,8 @@
         <lang.braceMatcher language="HOCON" implementationClass="org.jetbrains.plugins.hocon.misc.HoconBraceMatcher"/>
         <lang.foldingBuilder language="HOCON"
                              implementationClass="org.jetbrains.plugins.hocon.misc.HoconFoldingBuilder"/>
+        <lang.psiStructureViewFactory language="HOCON"
+                                      implementationClass="org.jetbrains.plugins.hocon.misc.HoconStructureViewFactory"/>
         <quoteHandler fileType="HOCON" className="org.jetbrains.plugins.hocon.editor.HoconQuoteHandler"/>
         <annotator language="HOCON"
                    implementationClass="org.jetbrains.plugins.hocon.highlight.HoconSyntaxHighlightingAnnotator"/>

--- a/src/org/jetbrains/plugins/hocon/misc/HoconStructureView.scala
+++ b/src/org/jetbrains/plugins/hocon/misc/HoconStructureView.scala
@@ -1,0 +1,116 @@
+package org.jetbrains.plugins.hocon
+package misc
+
+import com.intellij.icons.AllIcons
+import com.intellij.ide.structureView.impl.common.PsiTreeElementBase
+import com.intellij.ide.structureView.{StructureViewBuilder, StructureViewModel, StructureViewModelBase, StructureViewTreeElement, TreeBasedStructureViewBuilder}
+import com.intellij.ide.util.treeView.smartTree.{SortableTreeElement, Sorter}
+import com.intellij.lang.PsiStructureViewFactory
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.{PsiElement, PsiFile}
+import org.jetbrains.plugins.hocon.psi.*
+
+import javax.swing.Icon
+
+class HoconStructureViewFactory extends PsiStructureViewFactory {
+  override def getStructureViewBuilder(psiFile: PsiFile): StructureViewBuilder = psiFile match {
+    case hoconFile: HoconPsiFile =>
+      new TreeBasedStructureViewBuilder {
+        override def createStructureViewModel(editor: Editor): StructureViewModel =
+          new HoconStructureViewModel(hoconFile, editor)
+      }
+    case _ => null
+  }
+}
+
+class HoconStructureViewModel(psiFile: HoconPsiFile, editor: Editor)
+  extends StructureViewModelBase(psiFile, editor, new HoconStructureViewElement(psiFile))
+    with StructureViewModel.ElementInfoProvider {
+
+  override def getSorters: Array[Sorter] = Array(Sorter.ALPHA_SORTER)
+
+  // Classes whose elements may be selected when syncing the tree with the editor caret.
+  override def getSuitableClasses: Array[Class[?]] =
+    Array(classOf[HObjectField], classOf[HInclude])
+
+  override def isAlwaysShowsPlus(element: StructureViewTreeElement): Boolean = false
+
+  override def isAlwaysLeaf(element: StructureViewTreeElement): Boolean = element.getValue match {
+    case _: HInclude => true
+    case _ => false
+  }
+}
+
+final class HoconStructureViewElement(element: PsiElement)
+  extends PsiTreeElementBase[PsiElement](element) with SortableTreeElement {
+
+  import HoconStructureViewElement.*
+
+  override def getChildrenBase: JList[StructureViewTreeElement] =
+    childEntries(element).map(e => new HoconStructureViewElement(e): StructureViewTreeElement).toJList
+
+  override def getPresentableText: String = element match {
+    case file: HoconPsiFile => file.getName
+    case of: HObjectField => pathText(of)
+    case incl: HInclude => includeText(incl)
+    case _ => element.getText
+  }
+
+  override def getLocationString: String = element match {
+    case of: HObjectField if getChildrenBase.isEmpty =>
+      valueOf(of).map(preview).orNull
+    case _ => null
+  }
+
+  override def getIcon(open: Boolean): Icon = element match {
+    case _: HoconPsiFile => HoconIcon
+    case _: HInclude => AllIcons.Nodes.Include
+    case _ => PropertyIcon
+  }
+
+  override def getAlphaSortKey: String =
+    Option(getPresentableText).getOrElse("")
+}
+
+object HoconStructureViewElement {
+
+  /** Child entries shown under a given element: top-level entries for the file, or the entries of an object-valued
+    * field. Includes are listed but not expanded.
+    */
+  private def childEntries(element: PsiElement): Iterator[HObjectEntry] = element match {
+    case file: HoconPsiFile =>
+      file.toplevelEntries.iterator.flatMap(_.entries(reverse = false))
+    case of: HObjectField =>
+      valueOf(of).iterator.flatMap(objectEntries)
+    case _ =>
+      Iterator.empty
+  }
+
+  /** Object entries directly contained in a value - looking through concatenations (e.g. `a = {...} {...}`). */
+  private def objectEntries(value: HValue): Iterator[HObjectEntry] = value match {
+    case obj: HObject => obj.entries.entries(reverse = false)
+    case conc: HConcatenation => conc.findChildren[HValue].flatMap(objectEntries)
+    case _ => Iterator.empty
+  }
+
+  /** The value finally assigned by an object field, looking through prefixed paths (e.g. `a.b.c = value`). */
+  private def valueOf(of: HObjectField): Option[HValue] =
+    of.keyedField.fieldsInPathForward.toSeq.lastOption.collectOnly[HValuedField].flatMap(_.value)
+
+  /** Dotted key path of a field, e.g. `foo.bar.baz` for `foo.bar.baz = ...`. */
+  private def pathText(of: HObjectField): String =
+    of.keyedField.fieldsInPathForward.map(_.keyString.getOrElse("?")).mkString(".")
+
+  private def includeText(incl: HInclude): String =
+    incl.included.target.map(t => s"include ${t.stringValue}").getOrElse("include")
+
+  /** A short, single-line preview of a leaf value to display next to the key. */
+  private def preview(value: HValue): String = {
+    val text = value match {
+      case _: HArray => "[…]"
+      case other => other.getText
+    }
+    val singleLine = text.replaceAll("\\s+", " ").trim
+    if (singleLine.length > 60) singleLine.take(59) + "…" else singleLine
+  }
+}

--- a/src/org/jetbrains/plugins/hocon/misc/HoconStructureViewFactory.scala
+++ b/src/org/jetbrains/plugins/hocon/misc/HoconStructureViewFactory.scala
@@ -1,14 +1,15 @@
 package org.jetbrains.plugins.hocon
 package misc
 
+import psi.*
+
 import com.intellij.icons.AllIcons
 import com.intellij.ide.structureView.impl.common.PsiTreeElementBase
-import com.intellij.ide.structureView.{StructureViewBuilder, StructureViewModel, StructureViewModelBase, StructureViewTreeElement, TreeBasedStructureViewBuilder}
+import com.intellij.ide.structureView.*
 import com.intellij.ide.util.treeView.smartTree.{SortableTreeElement, Sorter}
 import com.intellij.lang.PsiStructureViewFactory
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.{PsiElement, PsiFile}
-import org.jetbrains.plugins.hocon.psi.*
 
 import javax.swing.Icon
 

--- a/src/org/jetbrains/plugins/hocon/misc/HoconStructureViewFactory.scala
+++ b/src/org/jetbrains/plugins/hocon/misc/HoconStructureViewFactory.scala
@@ -9,6 +9,7 @@ import com.intellij.ide.structureView.*
 import com.intellij.ide.util.treeView.smartTree.{SortableTreeElement, Sorter}
 import com.intellij.lang.PsiStructureViewFactory
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.{PsiElement, PsiFile}
 
 import javax.swing.Icon
@@ -36,10 +37,7 @@ class HoconStructureViewModel(psiFile: HoconPsiFile, editor: Editor)
 
   override def isAlwaysShowsPlus(element: StructureViewTreeElement): Boolean = false
 
-  override def isAlwaysLeaf(element: StructureViewTreeElement): Boolean = element.getValue match {
-    case _: HInclude => true
-    case _ => false
-  }
+  override def isAlwaysLeaf(element: StructureViewTreeElement): Boolean = element.getValue.isInstanceOf[HInclude]
 }
 
 final class HoconStructureViewElement(element: PsiElement)
@@ -52,14 +50,14 @@ final class HoconStructureViewElement(element: PsiElement)
 
   override def getPresentableText: String = element match {
     case file: HoconPsiFile => file.getName
-    case of: HObjectField => pathText(of)
-    case incl: HInclude => includeText(incl)
+    case objectField: HObjectField => pathText(objectField)
+    case hInclude: HInclude => includeText(hInclude)
     case _ => element.getText
   }
 
   override def getLocationString: String = element match {
-    case of: HObjectField if getChildrenBase.isEmpty =>
-      valueOf(of).map(preview).orNull
+    case objectField: HObjectField if childEntries(element).isEmpty =>
+      valueOf(objectField).map(preview).orNull
     case _ => null
   }
 
@@ -69,8 +67,7 @@ final class HoconStructureViewElement(element: PsiElement)
     case _ => PropertyIcon
   }
 
-  override def getAlphaSortKey: String =
-    Option(getPresentableText).getOrElse("")
+  override def getAlphaSortKey: String = getPresentableText.opt.mkString
 }
 
 object HoconStructureViewElement {
@@ -81,8 +78,8 @@ object HoconStructureViewElement {
   private def childEntries(element: PsiElement): Iterator[HObjectEntry] = element match {
     case file: HoconPsiFile =>
       file.toplevelEntries.iterator.flatMap(_.entries(reverse = false))
-    case of: HObjectField =>
-      valueOf(of).iterator.flatMap(objectEntries)
+    case objectField: HObjectField =>
+      valueOf(objectField).iterator.flatMap(objectEntries)
     case _ =>
       Iterator.empty
   }
@@ -90,7 +87,7 @@ object HoconStructureViewElement {
   /** Object entries directly contained in a value - looking through concatenations (e.g. `a = {...} {...}`). */
   private def objectEntries(value: HValue): Iterator[HObjectEntry] = value match {
     case obj: HObject => obj.entries.entries(reverse = false)
-    case conc: HConcatenation => conc.findChildren[HValue].flatMap(objectEntries)
+    case concat: HConcatenation => concat.findChildren[HValue].flatMap(objectEntries)
     case _ => Iterator.empty
   }
 
@@ -111,7 +108,6 @@ object HoconStructureViewElement {
       case _: HArray => "[…]"
       case other => other.getText
     }
-    val singleLine = text.replaceAll("\\s+", " ").trim
-    if (singleLine.length > 60) singleLine.take(59) + "…" else singleLine
+    StringUtil.shortenTextWithEllipsis(StringUtil.collapseWhiteSpace(text), 60, 0, true)
   }
 }

--- a/test/org/jetbrains/plugins/hocon/misc/HoconStructureViewTest.scala
+++ b/test/org/jetbrains/plugins/hocon/misc/HoconStructureViewTest.scala
@@ -1,0 +1,56 @@
+package org.jetbrains.plugins.hocon
+package misc
+
+import com.intellij.ide.util.treeView.smartTree.TreeElement
+import com.intellij.testFramework.LightPlatformCodeInsightTestCase
+import org.jetbrains.plugins.hocon.psi.HoconPsiFile
+import org.junit.Assert.assertEquals
+
+class HoconStructureViewTest extends LightPlatformCodeInsightTestCase {
+
+  private def render(text: String): String = {
+    configureFromFileText("test.conf", text)
+    val file = getFile.asInstanceOf[HoconPsiFile]
+    val model = new HoconStructureViewModel(file, getEditor)
+    try {
+      val sb = new StringBuilder
+      def walk(el: TreeElement, depth: Int): Unit = {
+        val p = el.getPresentation
+        val loc = Option(p.getLocationString).filter(_.nonEmpty).map(s => s" = $s").getOrElse("")
+        sb.append("  " * depth).append(p.getPresentableText).append(loc).append('\n')
+        el.getChildren.foreach(walk(_, depth + 1))
+      }
+      model.getRoot.getChildren.foreach(walk(_, 0))
+      sb.toString
+    } finally model.dispose()
+  }
+
+  def testTree(): Unit = {
+    val conf =
+      """server {
+        |  host = localhost
+        |  port = 8080
+        |}
+        |db.url = "jdbc:postgresql://localhost/app"
+        |list = [1, 2, 3]
+        |a.b.c {
+        |  d = true
+        |}
+        |include "common.conf"
+        |""".stripMargin
+    // - objects are expanded, leaf values show a value preview
+    // - prefixed paths (a.b.c) collapse to a single node
+    // - arrays show a compact placeholder, includes are listed as leaves
+    val expected =
+      """server
+        |  host = localhost
+        |  port = 8080
+        |db.url = "jdbc:postgresql://localhost/app"
+        |list = […]
+        |a.b.c
+        |  d = true
+        |include common.conf
+        |""".stripMargin
+    assertEquals(expected, render(conf))
+  }
+}


### PR DESCRIPTION
Implement a PsiStructureViewFactory so HOCON files can be navigated via the Structure tool window. The tree mirrors the config hierarchy:

- objects expand into their entries (recursing through concatenated objects)
- prefixed paths (a.b.c) collapse into a single node
- leaf values show a truncated single-line preview; arrays show [...]
- include directives are listed as leaf nodes

Supports alphabetical sorting and autoscroll-from-source. Each node navigates to its key in the editor.

Closes #37

Co-Authored-By: Claude